### PR TITLE
Fix chatbot not working error

### DIFF
--- a/netlify/functions/server.js
+++ b/netlify/functions/server.js
@@ -25,13 +25,9 @@ console.log('- Supabase Service Role Key:', process.env.REACT_SUPABASE_SERVICE_R
 // ===== Middleware Setup =====
 // Allow requests from frontend
 app.use(cors({
-  origin: [
-    'http://localhost:3000',
-    'http://localhost:5173',
-    'http://127.0.0.1:5173',
-    'https://sagradago.online',
-    'https://www.sagradago.online'
-  ],
+  origin: (origin, callback) => {
+    callback(null, true);
+  },
   methods: ['GET', 'POST'],
   credentials: true
 }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react-router-dom": "^6.21.3",
         "react-scripts": "5.0.1",
         "recharts": "^2.15.3",
+        "serverless-http": "^3.2.0",
         "uuid": "^11.1.0",
         "web-vitals": "^2.1.4"
       },
@@ -20657,6 +20658,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serverless-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.2.0.tgz",
+      "integrity": "sha512-QvSyZXljRLIGqwcJ4xsKJXwkZnAVkse1OajepxfjkBXV0BMvRS5R546Z4kCBI8IygDzkQY0foNPC/rnipaE9pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/set-function-length": {

--- a/server/server.js
+++ b/server/server.js
@@ -24,13 +24,10 @@ console.log('- Supabase Service Role Key:', process.env.REACT_SUPABASE_SERVICE_R
 // ===== Middleware Setup =====
 // Allow requests from frontend
 app.use(cors({
-  origin: [
-    'http://localhost:3000',
-    'http://localhost:5173',
-    'http://127.0.0.1:5173',
-    'https://sagradago.online',
-    'https://www.sagradago.online'
-  ],
+  origin: (origin, callback) => {
+    // Allow requests from any origin; production is handled by Netlify same-origin
+    callback(null, true);
+  },
   methods: ['GET', 'POST'],
   credentials: true
 }));

--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -43,8 +43,8 @@ const Chatbot = () => {
     if (isLocalhost) {
       return 'http://localhost:5001';
     }
-    // Default for Netlify Functions deployment where Express is wrapped as a function
-    return '/.netlify/functions/server';
+    // In production, rely on same-origin \/api which Netlify redirects to the function
+    return '/api';
   };
   const API_BASE_URL = getApiBaseUrl();
   /**


### PR DESCRIPTION
Correct chatbot API endpoint to use same-origin `/api` and relax CORS to resolve connection failures.

The frontend was configured to call `/.netlify/functions/server` directly in production, which conflicted with Netlify's `netlify.toml` redirects that map `/api/*` to the serverless function. This mismatch prevented the chatbot from connecting. Additionally, restrictive CORS settings were causing cross-origin errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fadf75c-a2c4-4e8a-b8b6-ca3de149ff13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1fadf75c-a2c4-4e8a-b8b6-ca3de149ff13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

